### PR TITLE
add Fast Excel comparison

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -7,6 +7,7 @@ use Maatwebsite\Excel\Facades\Excel;
 use App\Exports\UsersExport;
 use Illuminate\Support\Facades\Storage;
 use Spatie\SimpleExcel\SimpleExcelWriter;
+use Rap2hpoutre\FastExcel\FastExcel;
 
 class ExportController extends Controller
 {
@@ -43,5 +44,40 @@ class ExportController extends Controller
         SimpleExcelWriter::streamDownload('users.csv')
             ->noHeaderRow()
             ->addRows($rows);
+    }
+
+    protected function usersGenerator()
+    {
+        // this method of chunking might be a hassle, but this is more optimal than just using cursor and yielding the result
+        $users = User::query();
+
+        $chunks_per_loop = 3000; // try changing this number according to the size of your data
+        $user_count = (clone $users)->count();
+        $chunks = (int) ceil(($user_count / $chunks_per_loop));
+
+        for ($i = 0; $i < $chunks; $i++) {
+            $clonedUser = (clone $users)->skip($i * $chunks_per_loop)
+                ->take($chunks_per_loop)
+                ->cursor();
+
+            foreach ($clonedUser as $user) {
+                yield $user;
+            }
+        }
+
+        // Normal, straightforward method, for smaller data this is the simplest way to use generator, but for bigger data, this is quite slow and uses a lot of memory
+
+        // foreach (User::cursor() as $user) {
+        //     yield $user;
+        // }
+    }
+
+    public function fastExcel()
+    {
+        $filename = 'storage/fast-excel-export.csv';
+
+        (new FastExcel($this->usersGenerator()))->export($filename);
+
+        return response()->download(public_path($filename));
     }
 }

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use App\Imports\UsersImport;
 use Spatie\SimpleExcel\SimpleExcelReader;
+use Rap2hpoutre\FastExcel\FastExcel;
 
 class ImportController extends Controller
 {
@@ -17,7 +18,7 @@ class ImportController extends Controller
         foreach ($users as $user) {
             $name = (string) Str::of($user[1])->before(' ');
 
-            if (! array_key_exists($name, $names)) {
+            if (!array_key_exists($name, $names)) {
                 $names[$name] = 0;
             }
 
@@ -37,7 +38,7 @@ class ImportController extends Controller
         foreach ($users[0] as $user) {
             $name = (string) Str::of($user[1])->before(' ');
 
-            if (! array_key_exists($name, $names)) {
+            if (!array_key_exists($name, $names)) {
                 $names[$name] = 0;
             }
 
@@ -59,5 +60,30 @@ class ImportController extends Controller
             ->sortDesc()
             ->take(10)
             ->dump();
+    }
+
+    public function fastExcel(Request $request)
+    {
+        $filePath = $request->file('file')->path();
+        $newFilePath =  $filePath . '.' . $request->file('file')->getClientOriginalExtension();
+        move_uploaded_file($filePath, $newFilePath);
+
+        $users = (new FastExcel)->withoutHeaders()->import($newFilePath);
+
+        $names = [];
+
+        foreach ($users as $user) {
+            $name = (string) Str::of($user[1])->before(' ');
+
+            if (!array_key_exists($name, $names)) {
+                $names[$name] = 0;
+            }
+
+            $names[$name]++;
+        }
+
+        arsort($names);
+
+        dump(array_slice($names, 0, 10));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "laravel/telescope": "^4.9",
         "laravel/tinker": "^2.5",
         "maatwebsite/excel": "^3.1",
+        "rap2hpoutre/fast-excel": "^3.2",
         "spatie/simple-excel": "^2.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e237488bd5380c6f52c377b37a90912d",
+    "content-hash": "a2d629f380f87075eb9ee3c063421228",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -61,6 +61,81 @@
                 "source": "https://github.com/asm89/stack-cors/tree/v2.1.1"
             },
             "time": "2022-01-18T09:12:03+00:00"
+        },
+        {
+            "name": "box/spout",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/box/spout.git",
+                "reference": "9bdb027d312b732515b884a341c0ad70372c6295"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/box/spout/zipball/9bdb027d312b732515b884a341c0ad70372c6295",
+                "reference": "9bdb027d312b732515b884a341c0ad70372c6295",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "ext-zip": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2",
+                "phpunit/phpunit": "^8"
+            },
+            "suggest": {
+                "ext-iconv": "To handle non UTF-8 CSV files (if \"php-intl\" is not already installed or is too limited)",
+                "ext-intl": "To handle non UTF-8 CSV files (if \"iconv\" is not already installed)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Box\\Spout\\": "src/Spout"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Adrien Loison",
+                    "email": "adrien@box.com"
+                }
+            ],
+            "description": "PHP Library to read and write spreadsheet files (CSV, XLSX and ODS), in a fast and scalable way",
+            "homepage": "https://www.github.com/box/spout",
+            "keywords": [
+                "OOXML",
+                "csv",
+                "excel",
+                "memory",
+                "odf",
+                "ods",
+                "office",
+                "open",
+                "php",
+                "read",
+                "scale",
+                "spreadsheet",
+                "stream",
+                "write",
+                "xlsx"
+            ],
+            "support": {
+                "issues": "https://github.com/box/spout/issues",
+                "source": "https://github.com/box/spout/tree/v3.3.0"
+            },
+            "abandoned": true,
+            "time": "2021-05-14T21:18:09+00:00"
         },
         {
             "name": "brick/math",
@@ -3494,6 +3569,69 @@
                 }
             ],
             "time": "2022-03-27T21:42:02+00:00"
+        },
+        {
+            "name": "rap2hpoutre/fast-excel",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rap2hpoutre/fast-excel.git",
+                "reference": "28183f3a90179386bfadcd0083129c247ce49fbe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rap2hpoutre/fast-excel/zipball/28183f3a90179386bfadcd0083129c247ce49fbe",
+                "reference": "28183f3a90179386bfadcd0083129c247ce49fbe",
+                "shasum": ""
+            },
+            "require": {
+                "box/spout": "^3",
+                "illuminate/support": "5.3.* || 5.4.* || 5.5.* || 5.6.* || 5.7.* || 5.8.* || ^6.0 || ^7.0 || ^8.0|^9.0",
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "illuminate/database": "^6.20.12 || ^7.30.4 || ^8.24.0|^9.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Rap2hpoutre\\FastExcel\\Providers\\FastExcelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions/fastexcel.php"
+                ],
+                "psr-4": {
+                    "Rap2hpoutre\\FastExcel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "rap2h",
+                    "email": "raphaelht@gmail.com"
+                }
+            ],
+            "description": "Fast Excel import/export for Laravel",
+            "keywords": [
+                "csv",
+                "excel",
+                "laravel",
+                "xls",
+                "xlsx"
+            ],
+            "support": {
+                "issues": "https://github.com/rap2hpoutre/fast-excel/issues",
+                "source": "https://github.com/rap2hpoutre/fast-excel/tree/v3.2.0"
+            },
+            "time": "2022-02-09T16:04:44+00:00"
         },
         {
             "name": "spatie/simple-excel",

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -42,23 +42,44 @@
                         </form>
                     </div>
 
+                    <div class="mt-8">
+                        <span class="text-lg font-bold">Fast Excel</span>
+                        <form action="{{ route('import.fast-excel') }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+
+                            <input type="file" name="file" required>
+
+                            <x-button>Import</x-button>
+                        </form>
+                    </div>
+
                     <hr class="my-8">
 
                     <div>
-                        <a href="{{ route('export.array') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        <a href="{{ route('export.array') }}"
+                            class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
                             Export using array
                         </a>
                     </div>
 
                     <div class="mt-4">
-                        <a href="{{ route('export.excel') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        <a href="{{ route('export.excel') }}"
+                            class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
                             Export using Laravel Excel
                         </a>
                     </div>
 
                     <div class="mt-4">
-                        <a href="{{ route('export.spatie') }}"class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                        <a
+                            href="{{ route('export.spatie') }}"class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
                             Export using Spatie Simple Excel
+                        </a>
+                    </div>
+
+                    <div class="mt-4">
+                        <a href="{{ route('export.fast-excel') }}"
+                            class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
+                            Export using Fast Excel
                         </a>
                     </div>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,11 +23,13 @@ Route::get('/', function () {
 Route::post('import/array', [ImportController::class, 'array'])->name('import.array');
 Route::post('import/excel', [ImportController::class, 'excel'])->name('import.excel');
 Route::post('import/spatie', [ImportController::class, 'spatie'])->name('import.spatie');
+Route::post('import/fast-excel', [ImportController::class, 'fastExcel'])->name('import.fast-excel');
 
 // Exports
 Route::get('export/array', [ExportController::class, 'array'])->name('export.array');
 Route::get('export/excel', [ExportController::class, 'excel'])->name('export.excel');
 Route::get('export/spatie', [ExportController::class, 'spatie'])->name('export.spatie');
+Route::get('export/fast-excel', [ExportController::class, 'fastExcel'])->name('export.fast-excel');
 
 Route::get('users', [\App\Http\Controllers\UserController::class, 'index'])->name('users.index');
 
@@ -36,4 +38,4 @@ Route::middleware('auth')->group(function () {
     Route::put('profile', [\App\Http\Controllers\ProfileController::class, 'update'])->name('profile.update');
 });
 
-require __DIR__.'/auth.php';
+require __DIR__ . '/auth.php';


### PR DESCRIPTION
Added [Fast Excel](https://github.com/rap2hpoutre/fast-excel) methods for comparison.

I find that with the right tweak, Fast Excel is the best in terms of memory usage in exporting although it can be slower than No packages or Spatie Excel.

In my local test:

- No packages: 2741 ms, 12 MB memory usage
- Spatie: 2873 ms, 58 MB memory usage
- Fast Excel: 4096 ms, 8 MB memory usage

For importing it's kinda in the middle between No packages and Spatie method in terms of duration and memory usage.

- No packages: 289 ms, 110 MB memory usage
- Spatie: 927 ms, 54 MB memory usage
- Fast Excel: 881 ms, 88 MB memory usage