### PR TITLE
change method 'chunk' to 'lazyById'

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -15,11 +15,16 @@ class ExportController extends Controller
     {
         $handle = fopen(public_path('storage/export.csv'), 'w');
 
-        User::chunk(2000, function ($users) use ($handle) {
-            foreach ($users->toArray() as $user) {
-                fputcsv($handle, $user);
-            }
-        });
+        // User::chunk(2000, function ($users) use ($handle) {
+        //     foreach ($users->toArray() as $user) {
+        //         fputcsv($handle, $user);
+        //     }
+        // });
+
+        User::query()->lazyById(2000, 'id')
+            ->each(function ($user) use ($handle) {
+                fputcsv($handle, $user->toArray());
+            });
 
         fclose($handle);
 
@@ -35,12 +40,16 @@ class ExportController extends Controller
     {
         $rows = [];
 
-        User::chunk(2000, function ($users) use (&$rows) {
-            foreach ($users->toArray() as $user) {
-                $rows[] = $user;
-            }
-        });
+        // User::chunk(2000, function ($users) use (&$rows) {
+        //     foreach ($users->toArray() as $user) {
+        //         $rows[] = $user;
+        //     }
+        // });
 
+        User::query()->lazyById(2000, 'id')
+            ->each(function ($user) use (&$rows) {
+                $rows[] = $user->toArray();
+            });
         SimpleExcelWriter::streamDownload('users.csv')
             ->noHeaderRow()
             ->addRows($rows);


### PR DESCRIPTION
in This PR, Change method `chunk` to `lazyById`.
## Before
When use `chunk` method, increase time of query each chunk, because query like below:
In my local test first query time is `23.72ms `  in the last query increase to `260.95ms`, and total duration is `7304.69ms`.
```sql
select * from `users` order by `users`.`id` asc limit 2000 offset 2000;
select * from `users` order by `users`.`id` asc limit 2000 offset 4000;
select * from `users` order by `users`.`id` asc limit 2000 offset 6000;
...
```

## After 
when use `lazyById` method, add where condition to queries and delete offset it causes all queries duration in normal and does not increase. executed query like below : 
In my local test all queries duration `12~18ms` and total duration is `730.55ms `.
```sql
select * from `users` where `id` > 2000 order by `id` asc limit 2000;
select * from `users` where `id` > 4000 order by `id` asc limit 2000;
select * from `users` where `id` > 6000 order by `id` asc limit 2000;
...
```
## Result 
**With this small change we can save about `6000ms`.**